### PR TITLE
Use Option::map in parse_month of episode #7

### DIFF
--- a/episode/7/humandate/src/lib.rs
+++ b/episode/7/humandate/src/lib.rs
@@ -35,10 +35,7 @@ impl From<std::num::ParseIntError> for Error {
 }
 
 fn parse_month(month: &str) -> Option<usize> {
-    match MONTH_NAMES.iter().position(|&elem| elem == month) {
-        Some(index) => Some(index + 1),
-        None => None,
-    }
+    MONTH_NAMES.iter().position(|&elem| elem == month).map(|day| day + 1)
 }
 
 fn parse_day(day_with_ordinal: &str) -> Result<u32, Error> {


### PR DESCRIPTION
Use [`Option::map`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map) instead of a match expression in the `parse_month` function. Makes it more readable.

Love your show BTW! :)