### PR TITLE
Added worker version for Go

### DIFF
--- a/episode/9/episode.yml
+++ b/episode/9/episode.yml
@@ -29,6 +29,8 @@ notes:
   - "Golang sync.Waitgroup: https://golang.org/pkg/sync/#WaitGroup"
   - "rayon crate for easy parallelism: https://github.com/rayon-rs/rayon"
   - "partition method: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.partition"
+errata:
+  - "[euantorano](https://github.com/euantorano) provided [an alternative Go approach to counting words](https://github.com/hello-rust/show/pull/46)."
 metas:
   - "Color scheme: JetJet Alternate for VSCode"
 licenses:

--- a/episode/9/go/worker.go
+++ b/episode/9/go/worker.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+func worker(tasks <-chan string, wordsChan chan<- string, errorsChan chan<- error, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	for filename := range tasks {
+		file, err := os.Open(filename)
+
+		if err != nil {
+			errorsChan <- err
+			continue
+		}
+
+		scanner := bufio.NewScanner(file)
+		scanner.Split(bufio.ScanWords)
+
+		for scanner.Scan() {
+			word := strings.ToLower(scanner.Text())
+
+			wordsChan <- word
+		}
+
+		if scanner.Err() != nil {
+			errorsChan <- scanner.Err()
+		}
+
+		file.Close()
+	}
+}
+
+func collectResults(m map[string]int, wordsChan <-chan string, errorsChan <-chan error) {
+	for {
+		select {
+		case word := <-wordsChan:
+			if _, ok := m[word]; ok {
+				m[word] += 1
+			} else {
+				m[word] = 1
+			}
+		case err := <-errorsChan:
+			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		}
+	}
+}
+
+func main() {
+	numArgs := len(os.Args) - 1
+
+	jobs := make(chan string, numArgs)
+	wordsChan := make(chan string, numArgs)
+	errorsChan := make(chan error, numArgs)
+
+	wordCount := make(map[string]int)
+	var wg sync.WaitGroup
+
+	wg.Add(runtime.NumCPU())
+
+	for w := 0; w < runtime.NumCPU(); w++ {
+		go worker(jobs, wordsChan, errorsChan, &wg)
+	}
+
+	go collectResults(wordCount, wordsChan, errorsChan)
+
+	for _, f := range os.Args[1:] {
+		jobs <- f
+	}
+
+	close(jobs)
+
+	wg.Wait()
+
+	fmt.Println("Words that appear more than once:")
+	for word, count := range wordCount {
+		if count > 1 {
+			fmt.Printf("%d %s\n", count, word)
+		}
+	}
+}


### PR DESCRIPTION
This adds a slightly modified version of the Go program for episode 9 which uses a worker pool and only creates as many goroutines as there are logical threads on the system.

The Rust version seems to act similarly - Rayon will only start one thread per CPU for the `par_iter()` as far as I understand it.

I haven't done any benchmarking to compare times between this and the `fixed.go` version, but thought it might be nice to see another approach to the problem, similar to #45.